### PR TITLE
detect the MRAA_VERSION env var to install mraa

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -5,7 +5,8 @@ var os = require("os");
 var useMraa = (function() {
   var release = os.release();
   return release.includes("yocto") ||
-    release.includes("edison");
+    release.includes("edison") ||
+    process.env.MRAA_VERSION;
 })();
 
 var safeBuild = "0.9.4";


### PR DESCRIPTION
This env var is present on the resin.io build platforms and will allow users of that platform to use galileo-io on that platform with out modifying their programs.