### PR TITLE
Fixes typo in the Intel Edison Arduino title

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ board.on("ready", function() {
 ```
 
 
-#### Intel Edison Arduino Breaout
+#### Intel Edison Arduino
 
 The [Intel Edison + Arduino Breakout](https://www.sparkfun.com/products/13097) has a pin-out form similar to an Arduino Uno. Use the pin numbers as printed on the board, eg. `3`, `13`, or `"A0"`.
 


### PR DESCRIPTION
I made this change so that the anchor name respects the board name used in the johnny-five board naming convention. Besides, it said "breaout" instead of breakout.